### PR TITLE
Include used frameworks.

### DIFF
--- a/CCARadialGradientLayer/CCARadialGradientLayer.h
+++ b/CCARadialGradientLayer/CCARadialGradientLayer.h
@@ -26,6 +26,7 @@
 //
 
 #import <QuartzCore/QuartzCore.h>
+#import <Foundation/Foundation.h>
 
 @interface CCARadialGradientLayer : CALayer
 

--- a/CCARadialGradientLayer/CCARadialGradientLayer.m
+++ b/CCARadialGradientLayer/CCARadialGradientLayer.m
@@ -25,6 +25,8 @@
 //  THE SOFTWARE.
 //
 
+#import "CCARadialGradientLayer.h"
+
 struct CCARadialGradientLayerProperties
 {
     __unsafe_unretained NSString *gradientOrigin;
@@ -39,8 +41,6 @@ const struct CCARadialGradientLayerProperties CCARadialGradientLayerProperties =
     .colors = @"colors",
     .locations = @"locations",
 };
-
-#import "CCARadialGradientLayer.h"
 
 @implementation CCARadialGradientLayer
 


### PR DESCRIPTION
Types from Foundation, such as NSString, are used in CCARadialGradientLayer. We must add Foundation framework to avoid compile errors.
